### PR TITLE
Generic Star Export Namespace handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,36 @@ function executeDynamicModule (id, setDynamicExportBinding) {
 }
 ```
 
+## Handling Namespace and Star Exports
+
+Some spec changes need to be made to support namespace star exports from Dynamic Modules.
+
+Consider the following example:
+
+lib.js
+```js
+export * from 'dynamic-module';
+```
+
+main1.js
+```js
+import { dynamicMethod } from './lib.js';
+```
+
+main2.js
+```js
+import * as lib from './lib.js';
+```
+
+`'main1.js'` can be supported fine, as the `ResolveExport` concrete method will ensure a placeholder for `dynamicMethod` that is then validated on execution.
+
+On the other hand, the namespace object for `'main2.js'` will not know the list of exported names from `'dynamic-module'` when it is created during instantiation.
+
+In order to support this, we introduce some book-keeping to track any Namespace Exotic Objects created that reference star exports of Dynamic Module Records.
+The post-execution of that dynamic module then amends the appropriate namespaces with new export names.
+
+This is well-defined because the namespace can never be accessed before the Dynamic Module has executed.
+
 ## FAQ
 
 ### Why not support constant bindings?
@@ -104,6 +134,7 @@ This specification for Dynamic Module Records takes a number of steps that are n
 
 * We are allowing the `ResolveExport` concrete method to define let-style export binding placeholders when called on dynamic modules to ensure availability during instantiate.
 * We are possibly extending new export names onto Namespace Exotic Objects after they have already been created.
+* In order to handle book-keeping on which Namespace Exotic Objects need this extension, we add a new parameter to `GetExportNames` tracking the requesting module.
 
 In addition, to ensure the above is well-defined, we provide a post-execution validation of export names, analogous what is done for Source Text Module Records at the instantiate phase.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <head><meta charset="utf-8">
-<title>Dynamic Modules</title><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"introduction","aoid":null,"title":"Introduction","titleHTML":"Introduction","number":"","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"Introduction"},{"type":"term","term":"Dynamic Module Record","refId":"sec-dynamic-module-records","referencingIds":["_ref_2","_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_11","_ref_12","_ref_14","_ref_15","_ref_16"],"id":"dynamicmodule-record","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","key":"Dynamic Module Record"},{"type":"table","id":"table-X","number":1,"caption":"Table 1: Additional Fields of Dynamic Module Records","referencingIds":["_ref_0"],"namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","key":"Table 1: Additional Fields of Dynamic Module Records"},{"type":"op","aoid":"CreateDynamicModule","refId":"sec-createdynamicmodule","location":"","referencingIds":[],"key":"CreateDynamicModule"},{"type":"clause","id":"sec-createdynamicmodule","aoid":"CreateDynamicModule","title":"CreateDynamicModule ( realm, hostDefined )","titleHTML":"CreateDynamicModule ( <var>realm</var>, <var>hostDefined</var> )","number":"1.1","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":["_ref_1"],"key":"CreateDynamicModule ( realm, hostDefined )"},{"type":"clause","id":"sec-getexportednames","aoid":null,"title":"GetExportedNames ( exportStarSet ) Concrete Method","titleHTML":"GetExportedNames ( <var>exportStarSet</var> ) Concrete Method","number":"1.2","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"GetExportedNames ( exportStarSet ) Concrete Method"},{"type":"clause","id":"sec-resolveexport","aoid":null,"title":"ResolveExport ( exportName, resolveSet ) Concrete Method","titleHTML":"ResolveExport ( <var>exportName</var>, <var>resolveSet</var> ) Concrete Method","number":"1.3","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"ResolveExport ( exportName, resolveSet ) Concrete Method"},{"type":"clause","id":"sec-moduledeclarationinstantiation","aoid":null,"title":"Instantiate ( ) Concrete Method","titleHTML":"Instantiate ( ) Concrete Method","number":"1.4","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"Instantiate ( ) Concrete Method"},{"type":"clause","id":"sec-moduleevaluation","aoid":null,"title":"Evaluate ( ) Concrete Method","titleHTML":"Evaluate ( ) Concrete Method","number":"1.5","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"Evaluate ( ) Concrete Method"},{"type":"clause","id":"sec-setdynamicexportbinding","aoid":null,"title":"SetDynamicExportBinding ( name, value ) Concrete Method","titleHTML":"SetDynamicExportBinding ( <var>name</var>, <var>value</var> ) Concrete Method","number":"1.6","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"SetDynamicExportBinding ( name, value ) Concrete Method"},{"type":"clause","id":"sec-dynamic-module-records","aoid":null,"title":"Dynamic Module Records","titleHTML":"Dynamic Module Records","number":"1","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"Dynamic Module Records"},{"type":"op","aoid":"HostEvaluateDynamicModule","refId":"sec-hostevaluatedynamicmodule","location":"","referencingIds":[],"key":"HostEvaluateDynamicModule"},{"type":"clause","id":"sec-hostevaluatedynamicmodule","aoid":"HostEvaluateDynamicModule","title":"Runtime Semantics: HostEvaluateDynamicModule ( dynamicModule )","titleHTML":"Runtime Semantics: HostEvaluateDynamicModule ( <var>dynamicModule</var> )","number":"2","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":["_ref_13"],"key":"Runtime Semantics: HostEvaluateDynamicModule ( dynamicModule )"}]</script></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#introduction" title="Introduction">Introduction</a></li><li><span class="item-toggle">◢</span><a href="#sec-dynamic-module-records" title="Dynamic Module Records"><span class="secnum">1</span> Dynamic Module Records</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-createdynamicmodule" title="CreateDynamicModule ( realm, hostDefined )"><span class="secnum">1.1</span> CreateDynamicModule ( <var>realm</var>, <var>hostDefined</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getexportednames" title="GetExportedNames ( exportStarSet ) Concrete Method"><span class="secnum">1.2</span> GetExportedNames ( <var>exportStarSet</var> ) Concrete Method</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolveexport" title="ResolveExport ( exportName, resolveSet ) Concrete Method"><span class="secnum">1.3</span> ResolveExport ( <var>exportName</var>, <var>resolveSet</var> ) Concrete Method</a></li><li><span class="item-toggle-none"></span><a href="#sec-moduledeclarationinstantiation" title="Instantiate ( ) Concrete Method"><span class="secnum">1.4</span> Instantiate ( ) Concrete Method</a></li><li><span class="item-toggle-none"></span><a href="#sec-moduleevaluation" title="Evaluate ( ) Concrete Method"><span class="secnum">1.5</span> Evaluate ( ) Concrete Method</a></li><li><span class="item-toggle-none"></span><a href="#sec-setdynamicexportbinding" title="SetDynamicExportBinding ( name, value ) Concrete Method"><span class="secnum">1.6</span> SetDynamicExportBinding ( <var>name</var>, <var>value</var> ) Concrete Method</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-hostevaluatedynamicmodule" title="Runtime Semantics: HostEvaluateDynamicModule ( dynamicModule )"><span class="secnum">2</span> RS: HostEvaluateDynamicModule ( <var>dynamicModule</var> )</a></li></ol></div></div><div id="spec-container"><h1 class="version first">Stage 0 Draft / July 12, 2018</h1><h1 class="title">Dynamic Modules</h1>
+<title>Dynamic Modules</title><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"introduction","aoid":null,"title":"Introduction","titleHTML":"Introduction","number":"","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"Introduction"},{"type":"table","id":"table-37","number":1,"caption":"Table 1: Abstract Methods of Module Records","referencingIds":[],"namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","key":"Table 1: Abstract Methods of Module Records"},{"type":"term","term":"ResolvedBinding Record","refId":"sec-abstract-module-records","referencingIds":["_ref_22","_ref_36"],"id":"resolvedbinding-record","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","key":"ResolvedBinding Record"},{"type":"clause","id":"sec-abstract-module-records","aoid":null,"title":"Abstract Module Records","titleHTML":"Abstract Module Records","number":"1.1.1.1","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":["_ref_1","_ref_3","_ref_9","_ref_11","_ref_15","_ref_19","_ref_20","_ref_24","_ref_28","_ref_32","_ref_35"],"key":"Abstract Module Records"},{"type":"clause","id":"sec-getexportednames","aoid":null,"title":"GetExportedNames ( exportStarSet, starExportModule ) Concrete Method","titleHTML":"GetExportedNames ( <var>exportStarSet</var>, <var>starExportModule</var> ) Concrete Method","number":"1.1.1.2.1","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"GetExportedNames ( exportStarSet, starExportModule ) Concrete Method"},{"type":"clause","id":"sec-source-text-module-records","aoid":null,"title":"Source Text Module Records","titleHTML":"Source Text Module Records","number":"1.1.1.2","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":["_ref_2","_ref_4"],"key":"Source Text Module Records"},{"type":"term","term":"Dynamic Module Record","refId":"sec-dynamic-module-records","referencingIds":["_ref_8","_ref_10","_ref_12","_ref_13","_ref_14","_ref_16","_ref_17","_ref_18","_ref_21","_ref_23","_ref_25","_ref_27","_ref_29","_ref_31","_ref_33","_ref_34"],"id":"dynamicmodule-record","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","key":"Dynamic Module Record"},{"type":"table","id":"table-X","number":2,"caption":"Table 2: Additional Fields of Dynamic Module Records","referencingIds":["_ref_0"],"namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","key":"Table 2: Additional Fields of Dynamic Module Records"},{"type":"op","aoid":"CreateDynamicModule","refId":"sec-createdynamicmodule","location":"","referencingIds":[],"key":"CreateDynamicModule"},{"type":"clause","id":"sec-createdynamicmodule","aoid":"CreateDynamicModule","title":"CreateDynamicModule ( realm, hostDefined )","titleHTML":"CreateDynamicModule ( <var>realm</var>, <var>hostDefined</var> )","number":"1.1.1.3.1","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":["_ref_7"],"key":"CreateDynamicModule ( realm, hostDefined )"},{"type":"clause","id":"sec-dynamicgetexportednames","aoid":null,"title":"GetExportedNames ( exportStarSet, starExportModule ) Concrete Method","titleHTML":"GetExportedNames ( <var>exportStarSet</var>, <var>starExportModule</var> ) Concrete Method","number":"1.1.1.3.2","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"GetExportedNames ( exportStarSet, starExportModule ) Concrete Method"},{"type":"clause","id":"sec-dynamicresolveexport","aoid":null,"title":"ResolveExport ( exportName, resolveSet ) Concrete Method","titleHTML":"ResolveExport ( <var>exportName</var>, <var>resolveSet</var> ) Concrete Method","number":"1.1.1.3.3","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"ResolveExport ( exportName, resolveSet ) Concrete Method"},{"type":"clause","id":"sec-dynamicmoduledeclarationinstantiation","aoid":null,"title":"Instantiate ( ) Concrete Method","titleHTML":"Instantiate ( ) Concrete Method","number":"1.1.1.3.4","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"Instantiate ( ) Concrete Method"},{"type":"clause","id":"sec-dynamicmoduleevaluation","aoid":null,"title":"Evaluate ( ) Concrete Method","titleHTML":"Evaluate ( ) Concrete Method","number":"1.1.1.3.5","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"Evaluate ( ) Concrete Method"},{"type":"clause","id":"sec-setdynamicexportbinding","aoid":null,"title":"SetDynamicExportBinding ( name, value ) Concrete Method","titleHTML":"SetDynamicExportBinding ( <var>name</var>, <var>value</var> ) Concrete Method","number":"1.1.1.3.6","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"SetDynamicExportBinding ( name, value ) Concrete Method"},{"type":"clause","id":"sec-dynamic-module-records","aoid":null,"title":"Dynamic Module Records","titleHTML":"Dynamic Module Records","number":"1.1.1.3","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"Dynamic Module Records"},{"type":"op","aoid":"HostEvaluateDynamicModule","refId":"sec-hostevaluatedynamicmodule","location":"","referencingIds":[],"key":"HostEvaluateDynamicModule"},{"type":"clause","id":"sec-hostevaluatedynamicmodule","aoid":"HostEvaluateDynamicModule","title":"Runtime Semantics: HostEvaluateDynamicModule ( dynamicModule )","titleHTML":"Runtime Semantics: HostEvaluateDynamicModule ( <var>dynamicModule</var> )","number":"1.1.1.4","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":["_ref_30"],"key":"Runtime Semantics: HostEvaluateDynamicModule ( dynamicModule )"},{"type":"op","aoid":"GetModuleNamespace","refId":"sec-getmodulenamespace","location":"","referencingIds":[],"key":"GetModuleNamespace"},{"type":"clause","id":"sec-getmodulenamespace","aoid":"GetModuleNamespace","title":"Runtime Semantics: GetModuleNamespace ( module )","titleHTML":"Runtime Semantics: GetModuleNamespace ( <var>module</var> )","number":"1.1.1.5","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"Runtime Semantics: GetModuleNamespace ( module )"},{"type":"clause","id":"sec-module-semantics","aoid":null,"title":"Module Semantics","titleHTML":"Module Semantics","number":"1.1.1","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"Module Semantics"},{"type":"clause","id":"sec-modules","aoid":null,"title":"Modules","titleHTML":"Modules","number":"1.1","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"Modules"},{"type":"clause","id":"sec-ecmascript-language-scripts-and-modules","aoid":null,"title":"ECMAScript Language: Scripts and Modules","titleHTML":"ECMAScript Language: Scripts and Modules","number":"1","namespace":"https://guybedford.github.io/proposal-dynamic-modules/","location":"","referencingIds":[],"key":"ECMAScript Language: Scripts and Modules"}]</script></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#introduction" title="Introduction">Introduction</a></li><li><span class="item-toggle">◢</span><a href="#sec-ecmascript-language-scripts-and-modules" title="ECMAScript Language: Scripts and Modules"><span class="secnum">1</span> ECMAScript Language: Scripts and Modules</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-modules" title="Modules"><span class="secnum">1.1</span> Modules</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-module-semantics" title="Module Semantics"><span class="secnum">1.1.1</span> Module Semantics</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-abstract-module-records" title="Abstract Module Records"><span class="secnum">1.1.1.1</span> Abstract Module Records</a></li><li><span class="item-toggle">◢</span><a href="#sec-source-text-module-records" title="Source Text Module Records"><span class="secnum">1.1.1.2</span> Source Text Module Records</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-getexportednames" title="GetExportedNames ( exportStarSet, starExportModule ) Concrete Method"><span class="secnum">1.1.1.2.1</span> GetExportedNames ( <var>exportStarSet</var>, <var>starExportModule</var> ) Concrete Method</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-dynamic-module-records" title="Dynamic Module Records"><span class="secnum">1.1.1.3</span> Dynamic Module Records</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-createdynamicmodule" title="CreateDynamicModule ( realm, hostDefined )"><span class="secnum">1.1.1.3.1</span> CreateDynamicModule ( <var>realm</var>, <var>hostDefined</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-dynamicgetexportednames" title="GetExportedNames ( exportStarSet, starExportModule ) Concrete Method"><span class="secnum">1.1.1.3.2</span> GetExportedNames ( <var>exportStarSet</var>, <var>starExportModule</var> ) Concrete Method</a></li><li><span class="item-toggle-none"></span><a href="#sec-dynamicresolveexport" title="ResolveExport ( exportName, resolveSet ) Concrete Method"><span class="secnum">1.1.1.3.3</span> ResolveExport ( <var>exportName</var>, <var>resolveSet</var> ) Concrete Method</a></li><li><span class="item-toggle-none"></span><a href="#sec-dynamicmoduledeclarationinstantiation" title="Instantiate ( ) Concrete Method"><span class="secnum">1.1.1.3.4</span> Instantiate ( ) Concrete Method</a></li><li><span class="item-toggle-none"></span><a href="#sec-dynamicmoduleevaluation" title="Evaluate ( ) Concrete Method"><span class="secnum">1.1.1.3.5</span> Evaluate ( ) Concrete Method</a></li><li><span class="item-toggle-none"></span><a href="#sec-setdynamicexportbinding" title="SetDynamicExportBinding ( name, value ) Concrete Method"><span class="secnum">1.1.1.3.6</span> SetDynamicExportBinding ( <var>name</var>, <var>value</var> ) Concrete Method</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-hostevaluatedynamicmodule" title="Runtime Semantics: HostEvaluateDynamicModule ( dynamicModule )"><span class="secnum">1.1.1.4</span> RS: HostEvaluateDynamicModule ( <var>dynamicModule</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-getmodulenamespace" title="Runtime Semantics: GetModuleNamespace ( module )"><span class="secnum">1.1.1.5</span> RS: GetModuleNamespace ( <var>module</var> )</a></li></ol></li></ol></li></ol></li></ol></div></div><div id="spec-container"><h1 class="version first">Stage 0 Draft / July 13, 2018</h1><h1 class="title">Dynamic Modules</h1>
 <script src="ecmarkup.js" defer=""></script>
 <link rel="stylesheet" href="ecmarkup.css">
 
@@ -11,150 +11,265 @@
   <p>In addition, they provide late definition of export bindings at the execution phase, to support named exports compatibility with legacy module systems.</p>
 </emu-intro>
 
-<emu-clause id="sec-dynamic-module-records">
-  <h1><span class="secnum">1</span>Dynamic Module Records</h1>
+<emu-clause id="sec-ecmascript-language-scripts-and-modules">
+  <h1><span class="secnum">1</span>ECMAScript Language: Scripts and Modules</h1>
+  <emu-clause id="sec-modules">
+    <h1><span class="secnum">1.1</span>Modules</h1>
 
-  <p>A  <dfn id="dynamicmodule-record">Dynamic Module Record</dfn> is used to represent information about a module that is defined programatically. Its fields contain digested information about the names that are exported by the module and its concrete methods use this digest to link, instantiate, and evaluate the module alongside other Abstract Module Records.</p>
-  
-  <p>Dependency cycles with Source Text Module Records are avoided since these modules can only export, and not import from other Abstract Module Records.</p>
+    <emu-clause id="sec-module-semantics">
+      <h1><span class="secnum">1.1.1</span>Module Semantics</h1>
 
-  <p>Dynamic Module Records support late export binding, in that export names are only validated after execution.</p>
+      <emu-clause id="sec-abstract-module-records">
+        <h1><span class="secnum">1.1.1.1</span>Abstract Module Records</h1>
 
-  <p>In addition to the fields, defined in  <emu-xref href="#table-36"><a href="https://tc39.github.io/ecma262/#table-36">Table 37</a></emu-xref>, Dynamic Module Records have the additional fields listed in  <emu-xref href="#table-X" id="_ref_0"><a href="#table-X">Table 1</a></emu-xref>. Each of these fields is initially set in <emu-xref aoid="CreateDynamicModule" id="_ref_1"><a href="#sec-createdynamicmodule">CreateDynamicModule</a></emu-xref>.</p>
+        <emu-table id="table-37" caption="Abstract Methods of Module Records"><figure><figcaption>Table 1: Abstract Methods of Module Records</figcaption>
+          <table>
+            <tbody>
+            <tr>
+              <th>
+                Method
+              
+              </th>
+              <th>
+                Purpose
+              
+              </th>
+            </tr>
+            <tr>
+              <td>
+                GetExportedNames(<var>exportStarSet</var><ins>, <var>starExportModule</var></ins>)
+              
+              </td>
+              <td>
+                Return a list of all names that are either directly or indirectly exported from this module.
+              
+              </td>
+            </tr>
+            <tr>
+              <td>
+                ResolveExport(<var>exportName</var>, <var>resolveSet</var>)
+              
+              </td>
+              <td>
+                <p>Return the binding of a name exported by this module. Bindings are represented by a  <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form { [[Module]]: <emu-xref href="#sec-abstract-module-records" id="_ref_1"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>, [[BindingName]]: String }. Return <emu-val>null</emu-val> if the name cannot be resolved, or <code>"ambiguous"</code> if multiple bindings were found.</p>
+                <p>This operation must be idempotent if it completes normally. Each time it is called with a specific <var>exportName</var>, <var>resolveSet</var> pair as arguments it must return the same result.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Instantiate()
+              
+              </td>
+              <td>
+                <p>Prepare the module for evaluation by transitively resolving all module dependencies and creating a module <emu-xref href="#sec-environment-records"><a href="https://tc39.github.io/ecma262/#sec-environment-records">Environment Record</a></emu-xref>.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Evaluate()
+              
+              </td>
+              <td>
+                <p>If this module has already been evaluated successfully, return <emu-val>undefined</emu-val>; if it has already been evaluated unsuccessfully, throw the exception that was produced. Otherwise, transitively evaluate all module dependencies of this module and then evaluate this module.</p>
+                <p>Instantiate must have completed successfully prior to invoking this method.</p>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </figure></emu-table>  
+      </emu-clause>
 
-  <emu-table id="table-X" caption="Additional Fields of Dynamic Module Records"><figure><figcaption>Table 1: Additional Fields of Dynamic Module Records</figcaption>
-    <table>
-      <tbody>
-      <tr>
-        <th>
-          Field Name
+      <emu-clause id="sec-source-text-module-records">
+        <h1><span class="secnum">1.1.1.2</span>Source Text Module Records</h1>
+
+        <emu-clause id="sec-getexportednames">
+          <h1><span class="secnum">1.1.1.2.1</span>GetExportedNames ( <var>exportStarSet</var>, <var>starExportModule</var> ) Concrete Method</h1>
+          <p>The GetExportedNames concrete method of a <emu-xref href="#sec-source-text-module-records" id="_ref_2"><a href="#sec-source-text-module-records">Source Text Module Record</a></emu-xref> implements the corresponding <emu-xref href="#sec-abstract-module-records" id="_ref_3"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> abstract method.</p>
+          <p>It performs the following steps:</p>
+          <emu-alg><ol><li>Let <var>module</var> be this <emu-xref href="#sec-source-text-module-records" id="_ref_4"><a href="#sec-source-text-module-records">Source Text Module Record</a></emu-xref>.</li><li>If <var>exportStarSet</var> contains <var>module</var>, then<ol><li>Assert: We've reached the starting point of an <code>import *</code> circularity.</li><li>Return a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li></ol></li><li>Append <var>module</var> to <var>exportStarSet</var>.</li><li>Let <var>exportedNames</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>For each ExportEntry <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> <var>e</var> in <var>module</var>.[[LocalExportEntries]], do<ol><li>Assert: <var>module</var> provides the direct binding for this export.</li><li>Append <var>e</var>.[[ExportName]] to <var>exportedNames</var>.</li></ol></li><li>For each ExportEntry <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> <var>e</var> in <var>module</var>.[[IndirectExportEntries]], do<ol><li>Assert: <var>module</var> imports a specific binding for this export.</li><li>Append <var>e</var>.[[ExportName]] to <var>exportedNames</var>.</li></ol></li><li>For each ExportEntry <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> <var>e</var> in <var>module</var>.[[StarExportEntries]], do<ol><li>Let <var>requestedModule</var> be ?&nbsp;<emu-xref aoid="HostResolveImportedModule" id="_ref_5"><a href="https://tc39.github.io/ecma262/#sec-hostresolveimportedmodule">HostResolveImportedModule</a></emu-xref>(<var>module</var>, <var>e</var>.[[ModuleRequest]]).</li><li>Let <var>starNames</var> be ? <var>requestedModule</var>.GetExportedNames(<var>exportStarSet</var><ins>, <var>starExportModule</var></ins>).</li><li>For each element <var>n</var> of <var>starNames</var>, do<ol><li>If <emu-xref aoid="SameValue" id="_ref_6"><a href="https://tc39.github.io/ecma262/#sec-samevalue">SameValue</a></emu-xref>(<var>n</var>, <code>"default"</code>) is <emu-val>false</emu-val>, then<ol><li>If <var>n</var> is not an element of <var>exportedNames</var>, then<ol><li>Append <var>n</var> to <var>exportedNames</var>.</li></ol></li></ol></li></ol></li></ol></li><li>Return <var>exportedNames</var>.
+          </li></ol></emu-alg>
+          <emu-note><span class="note">Note</span><div class="note-contents">
+            <p>GetExportedNames does not filter out or throw an exception for names that have ambiguous star export bindings.</p>
+          </div></emu-note>
+        </emu-clause>
+      </emu-clause>
+
+      <ins>
+      <emu-clause id="sec-dynamic-module-records">
+        <h1><span class="secnum">1.1.1.3</span>Dynamic Module Records</h1>
+
+        <p>A  <dfn id="dynamicmodule-record">Dynamic Module Record</dfn> is used to represent information about a module that is defined programatically. Its fields contain digested information about the names that are exported by the module and its concrete methods use this digest to link, instantiate, and evaluate the module alongside other Abstract Module Records.</p>
         
-        </th>
-        <th>
-          Value Type
+        <p>Dependency cycles with Source Text Module Records are avoided since these modules can only export, and not import from other Abstract Module Records.</p>
+
+        <p>Dynamic Module Records support late export binding, in that export names are only validated after execution.</p>
+
+        <p>In addition to the fields, defined in  <emu-xref href="#table-36"><a href="https://tc39.github.io/ecma262/#table-36">Table 37</a></emu-xref>, Dynamic Module Records have the additional fields listed in  <emu-xref href="#table-X" id="_ref_0"><a href="#table-X">Table 2</a></emu-xref>. Each of these fields is initially set in <emu-xref aoid="CreateDynamicModule" id="_ref_7"><a href="#sec-createdynamicmodule">CreateDynamicModule</a></emu-xref>.</p>
+
+        <emu-table id="table-X" caption="Additional Fields of Dynamic Module Records"><figure><figcaption>Table 2: Additional Fields of Dynamic Module Records</figcaption>
+          <table>
+            <tbody>
+            <tr>
+              <th>
+                Field Name
+              
+              </th>
+              <th>
+                Value Type
+              
+              </th>
+              <th>
+                Meaning
+              
+              </th>
+            </tr>
+            <tr>
+              <td>
+                [[ExportNames]]
+              
+              </td>
+              <td>
+                A string <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of exported names.
+              
+              </td>
+              <td>
+                The list of export bindings associated with this <emu-xref href="#dynamicmodule-record" id="_ref_8"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>.
+              
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[StarExportModules]]
+              
+              </td>
+              <td>
+                A <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#sec-abstract-module-records" id="_ref_9"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> objects that export all names from this <emu-xref href="#dynamicmodule-record" id="_ref_10"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>.
+              
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[EvaluationError]]
+              
+              </td>
+              <td>
+                An <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref> | <emu-val>undefined</emu-val>
+              
+              </td>
+              <td>
+                A completion of type <emu-const>throw</emu-const> representing the exception that occurred during evaluation.  <emu-val>undefined</emu-val> if no exception occurred or if [[Status]] is not <code>"evaluated"</code>.
+              
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </figure></emu-table>
         
-        </th>
-        <th>
-          Meaning
-        
-        </th>
-      </tr>
-      <tr>
-        <td>
-          [[ExportNames]]
-        
-        </td>
-        <td>
-          A string <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of exported names.
-        
-        </td>
-        <td>
-          The list of export bindings associated with this dynamic <emu-xref href="#sec-abstract-module-records"><a href="https://tc39.github.io/ecma262/#sec-abstract-module-records">Module Record</a></emu-xref>.
-        
-        </td>
-      </tr>
-      <tr>
-        <td>
-          [[EvaluationError]]
-        
-        </td>
-        <td>
-          An <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref> | <emu-val>undefined</emu-val>
-        
-        </td>
-        <td>
-          A completion of type <emu-const>throw</emu-const> representing the exception that occurred during evaluation.  <emu-val>undefined</emu-val> if no exception occurred or if [[Status]] is not <code>"evaluated"</code>.
-        
-        </td>
-      </tr>
-      </tbody>
-    </table>
-  </figure></emu-table>
-  
-  <emu-clause id="sec-createdynamicmodule" aoid="CreateDynamicModule">
-    <h1><span class="secnum">1.1</span>CreateDynamicModule ( <var>realm</var>, <var>hostDefined</var> )</h1>
-    <p>This method would be expected to be called by the host when constructing a <emu-xref href="#sec-abstract-module-records"><a href="https://tc39.github.io/ecma262/#sec-abstract-module-records">Module Record</a></emu-xref> in <var>HostResolveImportedModule</var>.</p>
-    <p>The abstract operation CreateDynamicModule with arguments <var>realm</var>, and <var>hostDefined</var> creates a new <emu-xref href="#dynamicmodule-record" id="_ref_2"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> performing the following steps:</p>
-    <emu-alg><ol><li>Let <var>exportNames</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Return the <emu-xref href="#dynamicmodule-record" id="_ref_3"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> { [[Realm]]: <var>realm</var>, [[Environment]]: <emu-val>undefined</emu-val>, [[Namespace]]: <emu-val>undefined</emu-val>, [[Status]]: <code>"uninstantiated"</code>, [[ExportNames]]: <var>exportNames</var>, [[EvaluationError]]: <emu-val>undefined</emu-val>, [[HostDefined]]: <var>hostDefined</var> }.
-    </li></ol></emu-alg>
+        <emu-clause id="sec-createdynamicmodule" aoid="CreateDynamicModule">
+          <h1><span class="secnum">1.1.1.3.1</span>CreateDynamicModule ( <var>realm</var>, <var>hostDefined</var> )</h1>
+          <p>This method would be expected to be called by the host when constructing a <emu-xref href="#sec-abstract-module-records" id="_ref_11"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> in <var>HostResolveImportedModule</var>.</p>
+          <p>The abstract operation CreateDynamicModule with arguments <var>realm</var>, and <var>hostDefined</var> creates a new <emu-xref href="#dynamicmodule-record" id="_ref_12"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> performing the following steps:</p>
+          <emu-alg><ol><li>Let <var>exportNames</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>starExportModules</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Let <var>module</var> be the <emu-xref href="#dynamicmodule-record" id="_ref_13"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> { [[Realm]]: <var>realm</var>, [[Environment]]: <emu-val>undefined</emu-val>, [[Namespace]]: <emu-val>undefined</emu-val>, [[Status]]: <code>"uninstantiated"</code>, [[ExportNames]]: <var>exportNames</var>, [[StarExportModules]]: <var>starExportModules</var>, [[EvaluationError]]: <emu-val>undefined</emu-val>, [[HostDefined]]: <var>hostDefined</var> }.</li><li>Add <var>module</var> to <var>module</var>.[[StarExportModules]].</li><li>Return <var>module</var>.
+          </li></ol></emu-alg>
+        </emu-clause>
+
+        <p>The following definitions specify the required concrete methods for Dynamic Module Records.</p>
+
+        <emu-clause id="sec-dynamicgetexportednames">
+          <h1><span class="secnum">1.1.1.3.2</span>GetExportedNames ( <var>exportStarSet</var>, <var>starExportModule</var> ) Concrete Method</h1>
+          <p>The GetExportedNames concrete method of a <emu-xref href="#dynamicmodule-record" id="_ref_14"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> implements the corresponding <emu-xref href="#sec-abstract-module-records" id="_ref_15"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> abstract method.</p>
+          <p>Any modules exporting names from this <emu-xref href="#dynamicmodule-record" id="_ref_16"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> are stored so their exports can be amended later on.</p>&gt;
+          
+          <p>It performs the following steps:</p>
+          <emu-alg><ol><li>Let <var>module</var> be this <emu-xref href="#dynamicmodule-record" id="_ref_17"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>.</li><li>If <var>module</var>.[[StarExportModules]] does not contain <var>starExportModule</var> then,<ol><li>Add <var>starExportModule</var> to <var>module</var>.[[StarExportModules]].</li></ol></li><li>Return <var>module</var>.[[exportNames]].
+          </li></ol></emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-dynamicresolveexport">
+          <h1><span class="secnum">1.1.1.3.3</span>ResolveExport ( <var>exportName</var>, <var>resolveSet</var> ) Concrete Method</h1>
+          <p>The ResolveExport concrete method of a <emu-xref href="#dynamicmodule-record" id="_ref_18"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> implements the corresponding <emu-xref href="#sec-abstract-module-records" id="_ref_19"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> abstract method.</p>
+
+          <p>ResolveExport ensures that a binding is created for the dynamic <emu-xref href="#sec-abstract-module-records" id="_ref_20"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>, lazily creating a binding if needed.</p>
+
+          <p>This abstract method performs the following steps:</p>
+
+          <emu-alg><ol><li>Let <var>module</var> be this <emu-xref href="#dynamicmodule-record" id="_ref_21"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>.</li><li>Let <var>exportNames</var> be <var>module</var>.[[ExportNames]].</li><li>If <var>exportNames</var> does not contain <var>exportName</var> then,<ol><li>Let <var>envRec</var> be the Module <emu-xref href="#sec-environment-records"><a href="https://tc39.github.io/ecma262/#sec-environment-records">Environment Record</a></emu-xref> <var>module</var>.[[Environment]]</li><li>If <var>envRec</var> does not already have a binding for <var>exportName</var> then,<ol><li>Perform ! <var>envRec</var>.CreateMutableBinding(<var>exportName</var>, <emu-val>false</emu-val>).</li></ol></li><li>Append <var>exportName</var> to the end of <var>exportNames</var>.</li></ol></li><li>Return <emu-xref href="#resolvedbinding-record" id="_ref_22"><a href="#resolvedbinding-record">ResolvedBinding Record</a></emu-xref> { [[Module]]: <var>module</var>, [[BindingName]]: <var>exportName</var> }.
+          </li></ol></emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-dynamicmoduledeclarationinstantiation">
+          <h1><span class="secnum">1.1.1.3.4</span>Instantiate ( ) Concrete Method</h1>
+
+          <p>The Instantiate concrete method of a <emu-xref href="#dynamicmodule-record" id="_ref_23"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> implements the corresponding <emu-xref href="#sec-abstract-module-records" id="_ref_24"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> abstract method.</p>
+          <p>On success, Instantiate transitions this module's [[Status]] from <code>"uninstantiated"</code> to <code>"instantiated"</code>. On failure, an exception is thrown and this module's [[Status]] remains <code>"uninstantiated"</code>.</p>
+
+          <p>This abstract method performs the following steps:</p>
+
+          <emu-alg><ol><li>Let <var>module</var> be this <emu-xref href="#dynamicmodule-record" id="_ref_25"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>.</li><li>Assert: <var>module</var>.[[Status]] is not <code>"instantiating"</code> or <code>"evaluating"</code>.</li><li>Let <var>realm</var> be module.[[Realm]].</li><li>Assert: <var>realm</var> is a valid <emu-xref href="#realm"><a href="https://tc39.github.io/ecma262/#realm">Realm</a></emu-xref>.</li><li>Let <var>env</var> be <emu-xref aoid="NewModuleEnvironment" id="_ref_26"><a href="https://tc39.github.io/ecma262/#sec-newmoduleenvironment">NewModuleEnvironment</a></emu-xref>(<var>realm</var>.[[GlobalEnv]]).</li><li>Set <var>module</var>.[[Environment]] to <var>env</var>.</li><li>Set <var>module</var>.[[Status]] to <code>"instantiated"</code>.</li><li>Return <emu-val>undefined</emu-val>.
+          </li></ol></emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-dynamicmoduleevaluation">
+          <h1><span class="secnum">1.1.1.3.5</span>Evaluate ( ) Concrete Method</h1>
+
+          <p>The Evaluate concrete method of a <emu-xref href="#dynamicmodule-record" id="_ref_27"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> implements the corresponding <emu-xref href="#sec-abstract-module-records" id="_ref_28"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> abstract method.</p>
+          <p>Evaluate transitions this module's [[Status]] from <code>"instantiated"</code> to <code>"evaluated"</code>.</p>
+
+          <p>If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</p>
+
+          <p>Evaluation of dynamic modules calls out to <var>HostEvaluateDynamicModule</var>, before finalising the export names of the dynamic modules. Any uninitialized export bindings throw a reference error at this stage.</p>
+
+          <p>This abstract method performs the following steps:</p>
+
+          <emu-alg><ol><li>Let <var>m</var> be this <emu-xref href="#dynamicmodule-record" id="_ref_29"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>.</li><li>Assert: <var>m</var>.[[Status]] is <code>"instantiated"</code> or <code>"evaluated"</code>.</li><li>Set <var>m</var>.[[Status]] to <code>"evaluating"</code>.</li><li>Let <var>result</var> be <emu-xref aoid="HostEvaluateDynamicModule" id="_ref_30"><a href="#sec-hostevaluatedynamicmodule">HostEvaluateDynamicModule</a></emu-xref>(<var>m</var>).</li><li>If <var>result</var> is an <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref>, then<ol><li>Assert: <var>m</var>.[[Status]] is <code>"evaluating"</code>.</li><li>Set <var>m</var>.[[Status]] to <code>"evaluated"</code>.</li><li>Set <var>m</var>.[[EvaluationError]] to <var>result</var>.</li><li>Return <var>result</var>.</li></ol></li><li>Let <var>envRec</var> be the value of <var>module</var>.[[Environment]].</li><li>For each string <var>exportName</var> in <var>m</var>.[[ExportNames]], do<ol><li>Assert: <var>envRec</var> has a binding for <var>exportName</var>.</li><li>If the binding for <var>exportName</var> in <var>envRec</var> is uninitialized then,<ol><li>Let <var>error</var> be a <emu-val>ReferenceError</emu-val> exception.</li><li>Set <var>m</var>.[[Status]] to <code>"evaluated"</code>.</li><li>Set <var>m</var>.[[EvaluationError]] to <var>error</var>.</li><li>Return <var>error</var>.</li></ol></li></ol></li><li>For each module <var>exportModule</var> in the list <var>m</var>.[[StarExportModules]].<ol><li>Let <var>n</var> be the value of <var>exportModule</var>.[[Namespace]].</li><li>If <var>n</var> is not <var>undefined</var> then,<ol><li>Assert: <var>n</var> is a Module Namespace Exotic Object.</li><li>For each string <var>exportName</var> in <var>m</var>.[[ExportNames]], do<ol><li>Let <var>namespaceExports</var> be <var>n</var>.[[Exports]].</li><li>If <var>namespaceExports</var> does not contain <var>exportName</var> then,<ol><li>Insert <var>exportName</var> in the list <var>namespaceExports</var> at the position corresponding to the sort order of <code>Array.prototype.sort</code> with <emu-val>undefined</emu-val> as <var>comparefn</var>.</li></ol></li></ol></li></ol></li></ol></li><li>Set <var>m</var>.[[Status]] to <code>"evaluated"</code>.</li><li>Assert: <var>m</var>.[[EvaluationError]] is <emu-val>undefined</emu-val>.</li><li>Return <emu-val>undefined</emu-val>.
+          </li></ol></emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-setdynamicexportbinding">
+          <h1><span class="secnum">1.1.1.3.6</span>SetDynamicExportBinding ( <var>name</var>, <var>value</var> ) Concrete Method</h1>
+          <p>The SetDynamicExportBinding concrete method of a <emu-xref href="#dynamicmodule-record" id="_ref_31"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> implements the corresponding <emu-xref href="#sec-abstract-module-records" id="_ref_32"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> abstract method for a string <var>name</var> and initialization value <var>value</var>.</p>
+          <p>After execution completion, only binding mutation is supported.</p>
+          <p>This method can return an error on <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref>.</p>
+          <emu-alg><ol><li>Let <var>module</var> be this <emu-xref href="#dynamicmodule-record" id="_ref_33"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>.</li><li>Let <var>envRec</var> be the module <emu-xref href="#sec-environment-records"><a href="https://tc39.github.io/ecma262/#sec-environment-records">Environment Record</a></emu-xref> <var>module</var>.[[Environment]].</li><li>If <var>envRec</var> has a binding for <var>name</var> then,<ol><li>If the binding for <var>name</var> in <var>envRec</var> has not been initialized then,<ol><li>If <var>module</var>.[[Status]] is <code>"evaluated"</code> then,<ol><li>Let <var>error</var> be a <emu-val>ReferenceError</emu-val> exception.</li><li>Return <var>error</var>.</li></ol></li><li>Perform <var>envRec</var>.InitializeBinding(<var>name</var>, <var>value</var>).</li></ol></li><li>Otherwise,<ol><li>Perform <var>envRec</var>.SetMutableBinding(<var>name</var>, <var>value</var>, <emu-val>true</emu-val>).</li></ol></li></ol></li><li>Otherwise,<ol><li>If <var>module</var>.[[Status]] is <code>"evaluated"</code> then,<ol><li>Let <var>error</var> be a <emu-val>ReferenceError</emu-val> exception.</li><li>Return <var>error</var>.</li></ol></li><li>Perform <var>envRec</var>.CreateMutableBinding(<var>name</var>, <emu-val>false</emu-val>).</li><li>Perform <var>envRec</var>.InitializeBinding(<var>name</var>, <var>value</var>).</li></ol></li><li>Return <emu-val>undefined</emu-val>.
+          </li></ol></emu-alg>
+        </emu-clause>
+      </emu-clause>
+      </ins>
+
+      <ins>
+      <emu-clause id="sec-hostevaluatedynamicmodule" aoid="HostEvaluateDynamicModule">
+        <h1><span class="secnum">1.1.1.4</span>Runtime Semantics: HostEvaluateDynamicModule ( <var>dynamicModule</var> )</h1>
+        <p>HostEvaluateDynamicModule is an implementation-defined abstract operation that performs programmatic execution of a <emu-xref href="#dynamicmodule-record" id="_ref_34"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>, <var>dynamicModule</var>.</p>
+        <p>The implementation of HostEvaluateDynamicModule must conform to the following requirements:</p>
+        <ul>
+          <li>
+            HostEvaluateDynamicModule will call the SetDynamicExportBinding concrete method on the <var>dynamicModule</var> to initialize the export bindings.
+          
+          </li>
+          <li>
+            If there is an evaluation error, it must be thrown.
+          
+          </li>
+        </ul>
+        <emu-note><span class="note">Note</span><div class="note-contents">
+          <p>HostEvaluateDynamicModule must not itself rely on checking what lexical bindings have already been initialized for the module. It is important that the bindings defined in evaluation are fully independent of what bindings are imported.</p>
+        </div></emu-note>
+      </emu-clause>
+      </ins>
+
+      <emu-clause id="sec-getmodulenamespace" aoid="GetModuleNamespace">
+        <h1><span class="secnum">1.1.1.5</span>Runtime Semantics: GetModuleNamespace ( <var>module</var> )</h1>
+
+        <p>The GetModuleNamespace abstract operation retrieves the Module Namespace Exotic object representing <var>module</var>'s exports, lazily creating it the first time it was requested, and storing it in <var>module</var>.[[Namespace]] for future retrieval.</p>
+
+        <p>This abstract operation performs the following steps:</p>
+
+        <emu-alg><ol><li>Assert: <var>module</var> is an instance of a concrete subclass of <emu-xref href="#sec-abstract-module-records" id="_ref_35"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>.</li><li>Assert: <var>module</var>.[[Status]] is not <code>"uninstantiated"</code>.</li><li>Assert: If <var>module</var>.[[Status]] is <code>"evaluated"</code>, <var>module</var>.[[EvaluationError]] is <emu-val>undefined</emu-val>.</li><li>Let <var>namespace</var> be <var>module</var>.[[Namespace]].</li><li>If <var>namespace</var> is <emu-val>undefined</emu-val>, then<ol><li>Let <var>exportedNames</var> be ? <var>module</var>.GetExportedNames(« »<ins>, <var>module</var></ins>).</li><li>Let <var>unambiguousNames</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>For each <var>name</var> that is an element of <var>exportedNames</var>, do<ol><li>Let <var>resolution</var> be ? <var>module</var>.ResolveExport(<var>name</var>, « »).</li><li>If <var>resolution</var> is a <emu-xref href="#resolvedbinding-record" id="_ref_36"><a href="#resolvedbinding-record">ResolvedBinding Record</a></emu-xref>, append <var>name</var> to <var>unambiguousNames</var>.</li></ol></li><li>Set <var>namespace</var> to <emu-xref aoid="ModuleNamespaceCreate" id="_ref_37"><a href="https://tc39.github.io/ecma262/#sec-modulenamespacecreate">ModuleNamespaceCreate</a></emu-xref>(<var>module</var>, <var>unambiguousNames</var>).</li></ol></li><li>Return <var>namespace</var>.
+        </li></ol></emu-alg>
+        <emu-note><span class="note">Note</span><div class="note-contents">
+          <p>The only way GetModuleNamespace can throw is via one of the triggered <emu-xref aoid="HostResolveImportedModule" id="_ref_38"><a href="https://tc39.github.io/ecma262/#sec-hostresolveimportedmodule">HostResolveImportedModule</a></emu-xref> calls. Unresolvable names are simply excluded from the namespace at this point. They will lead to a real instantiation error later unless they are all ambiguous star exports that are not explicitly requested anywhere.</p>
+        </div></emu-note>
+      </emu-clause>
+    </emu-clause>
   </emu-clause>
-
-  <p>The following definitions specify the required concrete methods for Dynamic Module Records.</p>
-
-  <emu-clause id="sec-getexportednames">
-    <h1><span class="secnum">1.2</span>GetExportedNames ( <var>exportStarSet</var> ) Concrete Method</h1>
-    <p>The GetExportedNames concrete method of a <emu-xref href="#dynamicmodule-record" id="_ref_4"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> implements the corresponding <emu-xref href="#sec-abstract-module-records"><a href="https://tc39.github.io/ecma262/#sec-abstract-module-records">Module Record</a></emu-xref> abstract method.</p>
-    <p>It performs the following steps:</p>
-    <emu-alg><ol><li>Let <var>module</var> be this <emu-xref href="#dynamicmodule-record" id="_ref_5"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>.</li><li>Return <var>module</var>.[[exportNames]].
-    </li></ol></emu-alg>
-  </emu-clause>
-
-  <emu-clause id="sec-resolveexport">
-    <h1><span class="secnum">1.3</span>ResolveExport ( <var>exportName</var>, <var>resolveSet</var> ) Concrete Method</h1>
-    <p>The ResolveExport concrete method of a <emu-xref href="#dynamicmodule-record" id="_ref_6"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> implements the corresponding <emu-xref href="#sec-abstract-module-records"><a href="https://tc39.github.io/ecma262/#sec-abstract-module-records">Module Record</a></emu-xref> abstract method.</p>
-
-    <p>ResolveExport ensures that a binding is created for the dynamic <emu-xref href="#sec-abstract-module-records"><a href="https://tc39.github.io/ecma262/#sec-abstract-module-records">Module Record</a></emu-xref>, lazily creating a binding if needed.</p>
-
-    <p>This abstract method performs the following steps:</p>
-
-    <emu-alg><ol><li>Let <var>module</var> be this <emu-xref href="#dynamicmodule-record" id="_ref_7"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>.</li><li>Let <var>exportNames</var> be <var>module</var>.[[ExportNames]].</li><li>If <var>exportNames</var> does not contain <var>exportName</var> then,<ol><li>Let <var>envRec</var> be the Module <emu-xref href="#sec-environment-records"><a href="https://tc39.github.io/ecma262/#sec-environment-records">Environment Record</a></emu-xref> <var>module</var>.[[Environment]]</li><li>If <var>envRec</var> does not already have a binding for <var>exportName</var> then,<ol><li>Perform ! <var>envRec</var>.CreateMutableBinding(<var>exportName</var>, <emu-val>false</emu-val>).</li></ol></li><li>Append <var>exportName</var> to the end of <var>exportNames</var>.</li></ol></li><li>Return ResolvedBinding <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Module]]: <var>module</var>, [[BindingName]]: <var>exportName</var> }.
-    </li></ol></emu-alg>
-  </emu-clause>
-
-  <emu-clause id="sec-moduledeclarationinstantiation">
-    <h1><span class="secnum">1.4</span>Instantiate ( ) Concrete Method</h1>
-
-    <p>The Instantiate concrete method of a <emu-xref href="#dynamicmodule-record" id="_ref_8"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> implements the corresponding <emu-xref href="#sec-abstract-module-records"><a href="https://tc39.github.io/ecma262/#sec-abstract-module-records">Module Record</a></emu-xref> abstract method.</p>
-    <p>On success, Instantiate transitions this module's [[Status]] from <code>"uninstantiated"</code> to <code>"instantiated"</code>. On failure, an exception is thrown and this module's [[Status]] remains <code>"uninstantiated"</code>.</p>
-
-    <p>This abstract method performs the following steps:</p>
-
-    <emu-alg><ol><li>Let <var>module</var> be this <emu-xref href="#dynamicmodule-record" id="_ref_9"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>.</li><li>Assert: <var>module</var>.[[Status]] is not <code>"instantiating"</code> or <code>"evaluating"</code>.</li><li>Let <var>realm</var> be module.[[Realm]].</li><li>Assert: <var>realm</var> is a valid <emu-xref href="#realm"><a href="https://tc39.github.io/ecma262/#realm">Realm</a></emu-xref>.</li><li>Let <var>env</var> be <emu-xref aoid="NewModuleEnvironment" id="_ref_10"><a href="https://tc39.github.io/ecma262/#sec-newmoduleenvironment">NewModuleEnvironment</a></emu-xref>(<var>realm</var>.[[GlobalEnv]]).</li><li>Set <var>module</var>.[[Environment]] to <var>env</var>.</li><li>Set <var>module</var>.[[Status]] to <code>"instantiated"</code>.</li><li>Return <emu-val>undefined</emu-val>.
-    </li></ol></emu-alg>
-  </emu-clause>
-
-  <emu-clause id="sec-moduleevaluation">
-    <h1><span class="secnum">1.5</span>Evaluate ( ) Concrete Method</h1>
-
-    <p>The Evaluate concrete method of a <emu-xref href="#dynamicmodule-record" id="_ref_11"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> implements the corresponding <emu-xref href="#sec-abstract-module-records"><a href="https://tc39.github.io/ecma262/#sec-abstract-module-records">Module Record</a></emu-xref> abstract method.</p>
-    <p>Evaluate transitions this module's [[Status]] from <code>"instantiated"</code> to <code>"evaluated"</code>.</p>
-
-    <p>If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</p>
-
-    <p>Evaluation of dynamic modules calls out to <var>HostEvaluateDynamicModule</var>, before finalising the export names of the dynamic modules. Any uninitialized export bindings throw a reference error at this stage.</p>
-
-    <p>This abstract method performs the following steps:</p>
-
-    <emu-alg><ol><li>Let <var>m</var> be this <emu-xref href="#dynamicmodule-record" id="_ref_12"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>.</li><li>Assert: <var>m</var>.[[Status]] is <code>"instantiated"</code> or <code>"evaluated"</code>.</li><li>Set <var>m</var>.[[Status]] to <code>"evaluating"</code>.</li><li>Let <var>result</var> be <emu-xref aoid="HostEvaluateDynamicModule" id="_ref_13"><a href="#sec-hostevaluatedynamicmodule">HostEvaluateDynamicModule</a></emu-xref>(<var>m</var>).</li><li>If <var>result</var> is an <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref>, then<ol><li>Assert: <var>m</var>.[[Status]] is <code>"evaluating"</code>.</li><li>Set <var>m</var>.[[Status]] to <code>"evaluated"</code>.</li><li>Set <var>m</var>.[[EvaluationError]] to <var>result</var>.</li><li>Return <var>result</var>.</li></ol></li><li>Let <var>n</var> be the value of <var>m</var>.[[Namespace]].</li><li>If <var>n</var> is not <var>undefined</var> then,<ol><li>Assert <var>n</var> is a Module Namespace Exotic Object.</li></ol></li><li>Let <var>envRec</var> be the value of <var>module</var>.[[Environment]].</li><li>For each string <var>exportName</var> in <var>m</var>.[[ExportNames]], do<ol><li>Assert: <var>envRec</var> has a binding for <var>exportName</var>.</li><li>If the binding for <var>exportName</var> in <var>envRec</var> is uninitialized then,<ol><li>Let <var>error</var> be a <emu-val>ReferenceError</emu-val> exception.</li><li>Set <var>m</var>.[[Status]] to <code>"evaluated"</code>.</li><li>Set <var>m</var>.[[EvaluationError]] to <var>error</var>.</li><li>Return <var>error</var>.</li></ol></li><li>If <var>n</var> is not <var>undefined</var> then,<ol><li>Let <var>namespaceExports</var> be <var>n</var>.[[Exports]].</li><li>If <var>namespaceExports</var> does not contain <var>exportName</var> then,<ol><li>Insert <var>exportName</var> in the list <var>namespaceExports</var> at the position corresponding to the sort order of <code>Array.prototype.sort</code> with <emu-val>undefined</emu-val> as <var>comparefn</var>.</li></ol></li></ol></li></ol></li><li>Set <var>m</var>.[[Status]] to <code>"evaluated"</code>.</li><li>Assert: <var>m</var>.[[EvaluationError]] is <emu-val>undefined</emu-val>.</li><li>Return <emu-val>undefined</emu-val>.
-    </li></ol></emu-alg>
-  </emu-clause>
-
-  <emu-clause id="sec-setdynamicexportbinding">
-    <h1><span class="secnum">1.6</span>SetDynamicExportBinding ( <var>name</var>, <var>value</var> ) Concrete Method</h1>
-    <p>The SetDynamicExportBinding concrete method of a <emu-xref href="#dynamicmodule-record" id="_ref_14"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref> implements the corresponding <emu-xref href="#sec-abstract-module-records"><a href="https://tc39.github.io/ecma262/#sec-abstract-module-records">Module Record</a></emu-xref> abstract method for a string <var>name</var> and initialization value <var>value</var>.</p>
-    <p>After execution completion, only binding mutation is supported.</p>
-    <p>This method can return an error on <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref>.</p>
-    <emu-alg><ol><li>Let <var>module</var> be this <emu-xref href="#dynamicmodule-record" id="_ref_15"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>.</li><li>Let <var>envRec</var> be the module <emu-xref href="#sec-environment-records"><a href="https://tc39.github.io/ecma262/#sec-environment-records">Environment Record</a></emu-xref> <var>module</var>.[[Environment]].</li><li>If <var>envRec</var> has a binding for <var>name</var> then,<ol><li>If the binding for <var>name</var> in <var>envRec</var> has not been initialized then,<ol><li>If <var>module</var>.[[Status]] is <code>"evaluated"</code> then,<ol><li>Let <var>error</var> be a <emu-val>ReferenceError</emu-val> exception.</li><li>Return <var>error</var>.</li></ol></li><li>Perform <var>envRec</var>.InitializeBinding(<var>name</var>, <var>value</var>).</li></ol></li><li>Otherwise,<ol><li>Perform <var>envRec</var>.SetMutableBinding(<var>name</var>, <var>value</var>, <emu-val>true</emu-val>).</li></ol></li></ol></li><li>Otherwise,<ol><li>If <var>module</var>.[[Status]] is <code>"evaluated"</code> then,<ol><li>Let <var>error</var> be a <emu-val>ReferenceError</emu-val> exception.</li><li>Return <var>error</var>.</li></ol></li><li>Perform <var>envRec</var>.CreateMutableBinding(<var>name</var>, <emu-val>false</emu-val>).</li><li>Perform <var>envRec</var>.InitializeBinding(<var>name</var>, <var>value</var>).</li></ol></li><li>Return <emu-val>undefined</emu-val>.
-    </li></ol></emu-alg>
-  </emu-clause>
-</emu-clause>
-
-<emu-clause id="sec-hostevaluatedynamicmodule" aoid="HostEvaluateDynamicModule">
-  <h1><span class="secnum">2</span>Runtime Semantics: HostEvaluateDynamicModule ( <var>dynamicModule</var> )</h1>
-  <p>HostEvaluateDynamicModule is an implementation-defined abstract operation that performs programmatic execution of a <emu-xref href="#dynamicmodule-record" id="_ref_16"><a href="#dynamicmodule-record">Dynamic Module Record</a></emu-xref>, <var>dynamicModule</var>.</p>
-  <p>The implementation of HostEvaluateDynamicModule must conform to the following requirements:</p>
-  <ul>
-    <li>
-      HostEvaluateDynamicModule will call the SetDynamicExportBinding concrete method on the <var>dynamicModule</var> to initialize the export bindings.
-    
-    </li>
-    <li>
-      If there is an evaluation error, it must be thrown.
-    
-    </li>
-  </ul>
-  <emu-note><span class="note">Note</span><div class="note-contents">
-    <p>HostEvaluateDynamicModule must not itself rely on checking what lexical bindings have already been initialized for the module. It is important that the bindings defined in evaluation are fully independent of what bindings are imported.</p>
-  </div></emu-note>
-</emu-clause>
-</div></body>
+</emu-clause></div></body>

--- a/spec.html
+++ b/spec.html
@@ -17,202 +17,342 @@ copyright: false
   <p>In addition, they provide late definition of export bindings at the execution phase, to support named exports compatibility with legacy module systems.</p>
 </emu-intro>
 
-<emu-clause id="sec-dynamic-module-records">
-  <h1>Dynamic Module Records</h1>
+<emu-clause id="sec-ecmascript-language-scripts-and-modules">
+  <h1>ECMAScript Language: Scripts and Modules</h1>
+  <emu-clause id="sec-modules">
+    <h1>Modules</h1>
 
-  <p>A <dfn id="dynamicmodule-record">Dynamic Module Record</dfn> is used to represent information about a module that is defined programatically. Its fields contain digested information about the names that are exported by the module and its concrete methods use this digest to link, instantiate, and evaluate the module alongside other Abstract Module Records.</p>
-  
-  <p>Dependency cycles with Source Text Module Records are avoided since these modules can only export, and not import from other Abstract Module Records.</p>
+    <emu-clause id="sec-module-semantics">
+      <h1>Module Semantics</h1>
 
-  <p>Dynamic Module Records support late export binding, in that export names are only validated after execution.</p>
+      <emu-clause id="sec-abstract-module-records">
+        <h1>Abstract Module Records</h1>
 
-  <p>In addition to the fields, defined in <emu-xref href="#table-36"></emu-xref>, Dynamic Module Records have the additional fields listed in <emu-xref href="#table-X"></emu-xref>. Each of these fields is initially set in CreateDynamicModule.</p>
+        <emu-table id="table-37" caption="Abstract Methods of Module Records">
+          <table>
+            <tbody>
+            <tr>
+              <th>
+                Method
+              </th>
+              <th>
+                Purpose
+              </th>
+            </tr>
+            <tr>
+              <td>
+                GetExportedNames(_exportStarSet_<ins>, _starExportModule_</ins>)
+              </td>
+              <td>
+                Return a list of all names that are either directly or indirectly exported from this module.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                ResolveExport(_exportName_, _resolveSet_)
+              </td>
+              <td>
+                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String }. Return *null* if the name cannot be resolved, or `"ambiguous"` if multiple bindings were found.</p>
+                <p>This operation must be idempotent if it completes normally. Each time it is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Instantiate()
+              </td>
+              <td>
+                <p>Prepare the module for evaluation by transitively resolving all module dependencies and creating a module Environment Record.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Evaluate()
+              </td>
+              <td>
+                <p>If this module has already been evaluated successfully, return *undefined*; if it has already been evaluated unsuccessfully, throw the exception that was produced. Otherwise, transitively evaluate all module dependencies of this module and then evaluate this module.</p>
+                <p>Instantiate must have completed successfully prior to invoking this method.</p>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </emu-table>  
+      </emu-clause>
 
-  <emu-table id="table-X" caption="Additional Fields of Dynamic Module Records">
-    <table>
-      <tbody>
-      <tr>
-        <th>
-          Field Name
-        </th>
-        <th>
-          Value Type
-        </th>
-        <th>
-          Meaning
-        </th>
-      </tr>
-      <tr>
-        <td>
-          [[ExportNames]]
-        </td>
-        <td>
-          A string List of exported names.
-        </td>
-        <td>
-          The list of export bindings associated with this dynamic Module Record.
-        </td>
-      </tr>
-      <tr>
-        <td>
-          [[EvaluationError]]
-        </td>
-        <td>
-          An abrupt completion | *undefined*
-        </td>
-        <td>
-          A completion of type ~throw~ representing the exception that occurred during evaluation.  *undefined* if no exception occurred or if [[Status]] is not `"evaluated"`.
-        </td>
-      </tr>
-      </tbody>
-    </table>
-  </emu-table>
-  
-  <emu-clause id="sec-createdynamicmodule" aoid="CreateDynamicModule">
-    <h1>CreateDynamicModule ( _realm_, _hostDefined_ )</h1>
-    <p>This method would be expected to be called by the host when constructing a Module Record in _HostResolveImportedModule_.</p>
-    <p>The abstract operation CreateDynamicModule with arguments _realm_, and _hostDefined_ creates a new Dynamic Module Record performing the following steps:</p>
-    <emu-alg>
-      1. Let _exportNames_ be a new empty List.
-      1. Return the Dynamic Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, [[Status]]: `"uninstantiated"`, [[ExportNames]]: _exportNames_, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_ }.
-    </emu-alg>
+      <emu-clause id="sec-source-text-module-records">
+        <h1>Source Text Module Records</h1>
+
+        <emu-clause id="sec-getexportednames">
+          <h1>GetExportedNames ( _exportStarSet_<ins>, _starExportModule_</ins> ) Concrete Method</h1>
+          <p>The GetExportedNames concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
+          <p>It performs the following steps:</p>
+          <emu-alg>
+            1. Let _module_ be this Source Text Module Record.
+            1. If _exportStarSet_ contains _module_, then
+              1. Assert: We've reached the starting point of an `import *` circularity.
+              1. Return a new empty List.
+            1. Append _module_ to _exportStarSet_.
+            1. Let _exportedNames_ be a new empty List.
+            1. For each ExportEntry Record _e_ in _module_.[[LocalExportEntries]], do
+              1. Assert: _module_ provides the direct binding for this export.
+              1. Append _e_.[[ExportName]] to _exportedNames_.
+            1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
+              1. Assert: _module_ imports a specific binding for this export.
+              1. Append _e_.[[ExportName]] to _exportedNames_.
+            1. For each ExportEntry Record _e_ in _module_.[[StarExportEntries]], do
+              1. Let _requestedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
+              1. Let _starNames_ be ? _requestedModule_.GetExportedNames(_exportStarSet_<ins>, _starExportModule_</ins>).
+              1. For each element _n_ of _starNames_, do
+                1. If SameValue(_n_, `"default"`) is *false*, then
+                  1. If _n_ is not an element of _exportedNames_, then
+                    1. Append _n_ to _exportedNames_.
+            1. Return _exportedNames_.
+          </emu-alg>
+          <emu-note>
+            <p>GetExportedNames does not filter out or throw an exception for names that have ambiguous star export bindings.</p>
+          </emu-note>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-dynamic-module-records">
+        <h1>Dynamic Module Records</h1>
+
+        <p>A <dfn id="dynamicmodule-record">Dynamic Module Record</dfn> is used to represent information about a module that is defined programatically. Its fields contain digested information about the names that are exported by the module and its concrete methods use this digest to link, instantiate, and evaluate the module alongside other Abstract Module Records.</p>
+        
+        <p>Dependency cycles with Source Text Module Records are avoided since these modules can only export, and not import from other Abstract Module Records.</p>
+
+        <p>Dynamic Module Records support late export binding, in that export names are only validated after execution.</p>
+
+        <p>In addition to the fields, defined in <emu-xref href="#table-36"></emu-xref>, Dynamic Module Records have the additional fields listed in <emu-xref href="#table-X"></emu-xref>. Each of these fields is initially set in CreateDynamicModule.</p>
+
+        <emu-table id="table-X" caption="Additional Fields of Dynamic Module Records">
+          <table>
+            <tbody>
+            <tr>
+              <th>
+                Field Name
+              </th>
+              <th>
+                Value Type
+              </th>
+              <th>
+                Meaning
+              </th>
+            </tr>
+            <tr>
+              <td>
+                [[ExportNames]]
+              </td>
+              <td>
+                A string List of exported names.
+              </td>
+              <td>
+                The list of export bindings associated with this Dynamic Module Record.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[StarExportModules]]
+              </td>
+              <td>
+                A List of Module Record objects that export all names from this Dynamic Module Record.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[EvaluationError]]
+              </td>
+              <td>
+                An abrupt completion | *undefined*
+              </td>
+              <td>
+                A completion of type ~throw~ representing the exception that occurred during evaluation.  *undefined* if no exception occurred or if [[Status]] is not `"evaluated"`.
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </emu-table>
+        
+        <emu-clause id="sec-createdynamicmodule" aoid="CreateDynamicModule">
+          <h1>CreateDynamicModule ( _realm_, _hostDefined_ )</h1>
+          <p>This method would be expected to be called by the host when constructing a Module Record in _HostResolveImportedModule_.</p>
+          <p>The abstract operation CreateDynamicModule with arguments _realm_, and _hostDefined_ creates a new Dynamic Module Record performing the following steps:</p>
+          <emu-alg>
+            1. Let _exportNames_ be a new empty List.
+            1. Let _starExportModules_ be a new empty List.
+            1. Let _module_ be the Dynamic Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, [[Status]]: `"uninstantiated"`, [[ExportNames]]: _exportNames_, [[StarExportModules]]: _starExportModules_, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_ }.
+            1. Add _module_ to _module_.[[StarExportModules]].
+            1. Return _module_.
+          </emu-alg>
+        </emu-clause>
+
+        <p>The following definitions specify the required concrete methods for Dynamic Module Records.</p>
+
+        <emu-clause id="sec-dynamicgetexportednames">
+          <h1>GetExportedNames ( _exportStarSet_, _starExportModule_ ) Concrete Method</h1>
+          <p>The GetExportedNames concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method.</p>
+          <p>Any modules exporting names from this Dynamic Module Record are stored so their exports can be amended later on.</p>>
+          <p>It performs the following steps:</p>
+          <emu-alg>
+            1. Let _module_ be this Dynamic Module Record.
+            1. If _module_.[[StarExportModules]] does not contain _starExportModule_ then,
+              1. Add _starExportModule_ to _module_.[[StarExportModules]].
+            1. Return _module_.[[exportNames]].
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-dynamicresolveexport">
+          <h1>ResolveExport ( _exportName_, _resolveSet_ ) Concrete Method</h1>
+          <p>The ResolveExport concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method.</p>
+
+          <p>ResolveExport ensures that a binding is created for the dynamic Module Record, lazily creating a binding if needed.</p>
+
+          <p>This abstract method performs the following steps:</p>
+
+          <emu-alg>
+            1. Let _module_ be this Dynamic Module Record.
+            1. Let _exportNames_ be _module_.[[ExportNames]].
+            1. If _exportNames_ does not contain _exportName_ then,
+              1. Let _envRec_ be the Module Environment Record _module_.[[Environment]]
+              1. If _envRec_ does not already have a binding for _exportName_ then,
+                1. Perform ! _envRec_.CreateMutableBinding(_exportName_, *false*).
+              1. Append _exportName_ to the end of _exportNames_.
+            1. Return ResolvedBinding Record { [[Module]]: _module_, [[BindingName]]: _exportName_ }.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-dynamicmoduledeclarationinstantiation">
+          <h1>Instantiate ( ) Concrete Method</h1>
+
+          <p>The Instantiate concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method.</p>
+          <p>On success, Instantiate transitions this module's [[Status]] from `"uninstantiated"` to `"instantiated"`. On failure, an exception is thrown and this module's [[Status]] remains `"uninstantiated"`.</p>
+
+          <p>This abstract method performs the following steps:</p>
+
+          <emu-alg>
+            1. Let _module_ be this Dynamic Module Record.
+            1. Assert: _module_.[[Status]] is not `"instantiating"` or `"evaluating"`.
+            1. Let _realm_ be module.[[Realm]].
+            1. Assert: _realm_ is a valid Realm.
+            1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
+            1. Set _module_.[[Environment]] to _env_.
+            1. Set _module_.[[Status]] to `"instantiated"`.
+            1. Return *undefined*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-dynamicmoduleevaluation">
+          <h1>Evaluate ( ) Concrete Method</h1>
+
+          <p>The Evaluate concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method.</p>
+          <p>Evaluate transitions this module's [[Status]] from `"instantiated"` to `"evaluated"`.</p>
+
+          <p>If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</p>
+
+          <p>Evaluation of dynamic modules calls out to _HostEvaluateDynamicModule_, before finalising the export names of the dynamic modules. Any uninitialized export bindings throw a reference error at this stage.</p>
+
+          <p>This abstract method performs the following steps:</p>
+
+          <emu-alg>
+            1. Let _m_ be this Dynamic Module Record.
+            1. Assert: _m_.[[Status]] is `"instantiated"` or `"evaluated"`.
+            1. Set _m_.[[Status]] to `"evaluating"`.
+            1. Let _result_ be HostEvaluateDynamicModule(_m_).
+            1. If _result_ is an abrupt completion, then
+              1. Assert: _m_.[[Status]] is `"evaluating"`.
+              1. Set _m_.[[Status]] to `"evaluated"`.
+              1. Set _m_.[[EvaluationError]] to _result_.
+              1. Return _result_.
+            1. Let _envRec_ be the value of _module_.[[Environment]].
+            1. For each string _exportName_ in _m_.[[ExportNames]], do
+              1. Assert: _envRec_ has a binding for _exportName_.
+              1. If the binding for _exportName_ in _envRec_ is uninitialized then,
+                1. Let _error_ be a *ReferenceError* exception.
+                1. Set _m_.[[Status]] to `"evaluated"`.
+                1. Set _m_.[[EvaluationError]] to _error_.
+                1. Return _error_.
+            1. For each module _exportModule_ in the list _m_.[[StarExportModules]].
+              1. Let _n_ be the value of _exportModule_.[[Namespace]].
+              1. If _n_ is not _undefined_ then,
+                1. Assert: _n_ is a Module Namespace Exotic Object.
+                1. For each string _exportName_ in _m_.[[ExportNames]], do
+                  1. Let _namespaceExports_ be _n_.[[Exports]].
+                  1. If _namespaceExports_ does not contain _exportName_ then,
+                    1. Insert _exportName_ in the list _namespaceExports_ at the position corresponding to the sort order of `Array.prototype.sort` with *undefined* as _comparefn_.
+            1. Set _m_.[[Status]] to `"evaluated"`.
+            1. Assert: _m_.[[EvaluationError]] is *undefined*.
+            1. Return *undefined*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-setdynamicexportbinding">
+          <h1>SetDynamicExportBinding ( _name_, _value_ ) Concrete Method</h1>
+          <p>The SetDynamicExportBinding concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method for a string _name_ and initialization value _value_.</p>
+          <p>After execution completion, only binding mutation is supported.</p>
+          <p>This method can return an error on abrupt completion.</p>
+          <emu-alg>
+            1. Let _module_ be this Dynamic Module Record.
+            1. Let _envRec_ be the module Environment Record _module_.[[Environment]].
+            1. If _envRec_ has a binding for _name_ then,
+              1. If the binding for _name_ in _envRec_ has not been initialized then,
+                1. If _module_.[[Status]] is `"evaluated"` then,
+                  1. Let _error_ be a *ReferenceError* exception.
+                  1. Return _error_.
+                1. Perform _envRec_.InitializeBinding(_name_, _value_).
+              1. Otherwise,
+                1. Perform _envRec_.SetMutableBinding(_name_, _value_, *true*).
+            1. Otherwise,
+              1. If _module_.[[Status]] is `"evaluated"` then,
+                1. Let _error_ be a *ReferenceError* exception.
+                1. Return _error_.
+              1. Perform _envRec_.CreateMutableBinding(_name_, *false*).
+              1. Perform _envRec_.InitializeBinding(_name_, _value_).
+            1. Return *undefined*.
+          </emu-alg>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-hostevaluatedynamicmodule" aoid="HostEvaluateDynamicModule">
+        <h1>Runtime Semantics: HostEvaluateDynamicModule ( _dynamicModule_ )</h1>
+        <p>HostEvaluateDynamicModule is an implementation-defined abstract operation that performs programmatic execution of a Dynamic Module Record, _dynamicModule_.</p>
+        <p>The implementation of HostEvaluateDynamicModule must conform to the following requirements:</p>
+        <ul>
+          <li>
+            HostEvaluateDynamicModule will call the SetDynamicExportBinding concrete method on the _dynamicModule_ to initialize the export bindings.
+          </li>
+          <li>
+            If there is an evaluation error, it must be thrown.
+          </li>
+        </ul>
+        <emu-note>
+          <p>HostEvaluateDynamicModule must not itself rely on checking what lexical bindings have already been initialized for the module. It is important that the bindings defined in evaluation are fully independent of what bindings are imported.</p>
+        </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-getmodulenamespace" aoid="GetModuleNamespace">
+        <h1>Runtime Semantics: GetModuleNamespace ( _module_ )</h1>
+
+        <p>The GetModuleNamespace abstract operation retrieves the Module Namespace Exotic object representing _module_'s exports, lazily creating it the first time it was requested, and storing it in _module_.[[Namespace]] for future retrieval.</p>
+
+        <p>This abstract operation performs the following steps:</p>
+
+        <emu-alg>
+          1. Assert: _module_ is an instance of a concrete subclass of Module Record.
+          1. Assert: _module_.[[Status]] is not `"uninstantiated"`.
+          1. Assert: If _module_.[[Status]] is `"evaluated"`, _module_.[[EvaluationError]] is *undefined*.
+          1. Let _namespace_ be _module_.[[Namespace]].
+          1. If _namespace_ is *undefined*, then
+            1. Let _exportedNames_ be ? _module_.GetExportedNames(&laquo; &raquo;<ins>, _module_</ins>).
+            1. Let _unambiguousNames_ be a new empty List.
+            1. For each _name_ that is an element of _exportedNames_, do
+              1. Let _resolution_ be ? _module_.ResolveExport(_name_, &laquo; &raquo;).
+              1. If _resolution_ is a ResolvedBinding Record, append _name_ to _unambiguousNames_.
+            1. Set _namespace_ to ModuleNamespaceCreate(_module_, _unambiguousNames_).
+          1. Return _namespace_.
+        </emu-alg>
+        <emu-note>
+          <p>The only way GetModuleNamespace can throw is via one of the triggered HostResolveImportedModule calls. Unresolvable names are simply excluded from the namespace at this point. They will lead to a real instantiation error later unless they are all ambiguous star exports that are not explicitly requested anywhere.</p>
+        </emu-note>
+      </emu-clause>
+    </emu-clause>
   </emu-clause>
-
-  <p>The following definitions specify the required concrete methods for Dynamic Module Records.</p>
-
-  <emu-clause id="sec-getexportednames">
-    <h1>GetExportedNames ( _exportStarSet_ ) Concrete Method</h1>
-    <p>The GetExportedNames concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method.</p>
-    <p>It performs the following steps:</p>
-    <emu-alg>
-      1. Let _module_ be this Dynamic Module Record.
-      1. Return _module_.[[exportNames]].
-    </emu-alg>
-  </emu-clause>
-
-  <emu-clause id="sec-resolveexport">
-    <h1>ResolveExport ( _exportName_, _resolveSet_ ) Concrete Method</h1>
-    <p>The ResolveExport concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method.</p>
-
-    <p>ResolveExport ensures that a binding is created for the dynamic Module Record, lazily creating a binding if needed.</p>
-
-    <p>This abstract method performs the following steps:</p>
-
-    <emu-alg>
-      1. Let _module_ be this Dynamic Module Record.
-      1. Let _exportNames_ be _module_.[[ExportNames]].
-      1. If _exportNames_ does not contain _exportName_ then,
-        1. Let _envRec_ be the Module Environment Record _module_.[[Environment]]
-        1. If _envRec_ does not already have a binding for _exportName_ then,
-          1. Perform ! _envRec_.CreateMutableBinding(_exportName_, *false*).
-        1. Append _exportName_ to the end of _exportNames_.
-      1. Return ResolvedBinding Record { [[Module]]: _module_, [[BindingName]]: _exportName_ }.
-    </emu-alg>
-  </emu-clause>
-
-  <emu-clause id="sec-moduledeclarationinstantiation">
-    <h1>Instantiate ( ) Concrete Method</h1>
-
-    <p>The Instantiate concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method.</p>
-    <p>On success, Instantiate transitions this module's [[Status]] from `"uninstantiated"` to `"instantiated"`. On failure, an exception is thrown and this module's [[Status]] remains `"uninstantiated"`.</p>
-
-    <p>This abstract method performs the following steps:</p>
-
-    <emu-alg>
-      1. Let _module_ be this Dynamic Module Record.
-      1. Assert: _module_.[[Status]] is not `"instantiating"` or `"evaluating"`.
-      1. Let _realm_ be module.[[Realm]].
-      1. Assert: _realm_ is a valid Realm.
-      1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
-      1. Set _module_.[[Environment]] to _env_.
-      1. Set _module_.[[Status]] to `"instantiated"`.
-      1. Return *undefined*.
-    </emu-alg>
-  </emu-clause>
-
-  <emu-clause id="sec-moduleevaluation">
-    <h1>Evaluate ( ) Concrete Method</h1>
-
-    <p>The Evaluate concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method.</p>
-    <p>Evaluate transitions this module's [[Status]] from `"instantiated"` to `"evaluated"`.</p>
-
-    <p>If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</p>
-
-    <p>Evaluation of dynamic modules calls out to _HostEvaluateDynamicModule_, before finalising the export names of the dynamic modules. Any uninitialized export bindings throw a reference error at this stage.</p>
-
-    <p>This abstract method performs the following steps:</p>
-
-    <emu-alg>
-      1. Let _m_ be this Dynamic Module Record.
-      1. Assert: _m_.[[Status]] is `"instantiated"` or `"evaluated"`.
-      1. Set _m_.[[Status]] to `"evaluating"`.
-      1. Let _result_ be HostEvaluateDynamicModule(_m_).
-      1. If _result_ is an abrupt completion, then
-        1. Assert: _m_.[[Status]] is `"evaluating"`.
-        1. Set _m_.[[Status]] to `"evaluated"`.
-        1. Set _m_.[[EvaluationError]] to _result_.
-        1. Return _result_.
-      1. Let _n_ be the value of _m_.[[Namespace]].
-      1. If _n_ is not _undefined_ then,
-        1. Assert _n_ is a Module Namespace Exotic Object.
-      1. Let _envRec_ be the value of _module_.[[Environment]].
-      1. For each string _exportName_ in _m_.[[ExportNames]], do
-        1. Assert: _envRec_ has a binding for _exportName_.
-        1. If the binding for _exportName_ in _envRec_ is uninitialized then,
-          1. Let _error_ be a *ReferenceError* exception.
-          1. Set _m_.[[Status]] to `"evaluated"`.
-          1. Set _m_.[[EvaluationError]] to _error_.
-          1. Return _error_.
-        1. If _n_ is not _undefined_ then,
-          1. Let _namespaceExports_ be _n_.[[Exports]].
-          1. If _namespaceExports_ does not contain _exportName_ then,
-            1. Insert _exportName_ in the list _namespaceExports_ at the position corresponding to the sort order of `Array.prototype.sort` with *undefined* as _comparefn_.
-      1. Set _m_.[[Status]] to `"evaluated"`.
-      1. Assert: _m_.[[EvaluationError]] is *undefined*.
-      1. Return *undefined*.
-    </emu-alg>
-  </emu-clause>
-
-  <emu-clause id="sec-setdynamicexportbinding">
-    <h1>SetDynamicExportBinding ( _name_, _value_ ) Concrete Method</h1>
-    <p>The SetDynamicExportBinding concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method for a string _name_ and initialization value _value_.</p>
-    <p>After execution completion, only binding mutation is supported.</p>
-    <p>This method can return an error on abrupt completion.</p>
-    <emu-alg>
-      1. Let _module_ be this Dynamic Module Record.
-      1. Let _envRec_ be the module Environment Record _module_.[[Environment]].
-      1. If _envRec_ has a binding for _name_ then,
-        1. If the binding for _name_ in _envRec_ has not been initialized then,
-          1. If _module_.[[Status]] is `"evaluated"` then,
-            1. Let _error_ be a *ReferenceError* exception.
-            1. Return _error_.
-          1. Perform _envRec_.InitializeBinding(_name_, _value_).
-        1. Otherwise,
-          1. Perform _envRec_.SetMutableBinding(_name_, _value_, *true*).
-      1. Otherwise,
-        1. If _module_.[[Status]] is `"evaluated"` then,
-          1. Let _error_ be a *ReferenceError* exception.
-          1. Return _error_.
-        1. Perform _envRec_.CreateMutableBinding(_name_, *false*).
-        1. Perform _envRec_.InitializeBinding(_name_, _value_).
-      1. Return *undefined*.
-    </emu-alg>
-  </emu-clause>
-</emu-clause>
-
-<emu-clause id="sec-hostevaluatedynamicmodule" aoid="HostEvaluateDynamicModule">
-  <h1>Runtime Semantics: HostEvaluateDynamicModule ( _dynamicModule_ )</h1>
-  <p>HostEvaluateDynamicModule is an implementation-defined abstract operation that performs programmatic execution of a Dynamic Module Record, _dynamicModule_.</p>
-  <p>The implementation of HostEvaluateDynamicModule must conform to the following requirements:</p>
-  <ul>
-    <li>
-      HostEvaluateDynamicModule will call the SetDynamicExportBinding concrete method on the _dynamicModule_ to initialize the export bindings.
-    </li>
-    <li>
-      If there is an evaluation error, it must be thrown.
-    </li>
-  </ul>
-  <emu-note>
-    <p>HostEvaluateDynamicModule must not itself rely on checking what lexical bindings have already been initialized for the module. It is important that the bindings defined in evaluation are fully independent of what bindings are imported.</p>
-  </emu-note>
 </emu-clause>


### PR DESCRIPTION
This handles the edge case of star exports from dynamic namespaces:

lib.js:
```js
export * from 'dynamic-module';
```

main.js:
```js
import * as lib from './lib.js';
console.log(lib.dynamic);
```