### PR TITLE
Adjusted execution for circular stacks

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -122,7 +122,7 @@ copyright: false
             <p>This abstract operation performs the following steps:</p>
 
             <emu-alg>
-              1. <del></del>If _module_ is not a Source Text Module Record, then</del>
+              1. <del>If _module_ is not a Source Text Module Record, then</del>
                 1. <del>Perform ? _module_.Evaluate().</del>
                 1. <del>Return _index_.</del>
               1. If _module_.[[Status]] is `"evaluated"`, then
@@ -136,7 +136,7 @@ copyright: false
                 1. Set _module_.[[DFSIndex]] to _index_.
                 1. Set _module_.[[DFSAncestorIndex]] to _index_.
                 1. Set _index_ to _index_ + 1.
-              1. <del></del>Append _module_ to _stack_.
+              1. <del>Append _module_ to _stack_</del>.
                 1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
                   1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
                   1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.

--- a/spec.html
+++ b/spec.html
@@ -111,6 +111,59 @@ copyright: false
             <p>GetExportedNames does not filter out or throw an exception for names that have ambiguous star export bindings.</p>
           </emu-note>
         </emu-clause>
+
+        <emu-clause>
+          <h1>Evaluate ( ) Concrete Method</h1>
+          <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
+            <h1>InnerModuleEvaluation ( _module_, _stack_, _index_ )</h1>
+
+            <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the Source Text Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
+
+            <p>This abstract operation performs the following steps:</p>
+
+            <emu-alg>
+              1. <del></del>If _module_ is not a Source Text Module Record, then</del>
+                1. <del>Perform ? _module_.Evaluate().</del>
+                1. <del>Return _index_.</del>
+              1. If _module_.[[Status]] is `"evaluated"`, then
+                1. If _module_.[[EvaluationError]] is *undefined*, return _index_.
+                1. Otherwise return _module_.[[EvaluationError]].
+              1. If _module_.[[Status]] is `"evaluating"`, return _index_.
+              1. Assert: _module_.[[Status]] is `"instantiated"`.
+              1. <ins>Append _module_ to _stack_.</ins>
+              1. <ins>If _module_ is a Source Text Module Record, then</ins>
+                1. Set _module_.[[Status]] to `"evaluating"`.
+                1. Set _module_.[[DFSIndex]] to _index_.
+                1. Set _module_.[[DFSAncestorIndex]] to _index_.
+                1. Set _index_ to _index_ + 1.
+              1. <del></del>Append _module_ to _stack_.
+                1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
+                  1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
+                  1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+                  1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
+                  1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
+                  1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
+                  1. If _requiredModule_.[[Status]] is `"evaluating"`, then
+                    1. Assert: _requiredModule_ is a Source Text Module Record.
+                    1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
+              1. <del>Perform ? ModuleExecution(_module_).</del>
+              1. Assert: _module_ occurs exactly once in _stack_.
+              1. Assert: <ins>_module_ is not an Abstract Module Record, or </ins>_module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
+              1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]]<ins>, or _module_ is not an Abstract Module Record</ins>, then
+                1. Let _done_ be *false*.
+                1. <ins>For each element _requiredModule_ of _stack_ in reverse order, and while _done_ is *false*, do</ins>
+                  1. <ins>Perform ? ModuleExecution(_requiredModule_).</ins>
+                  1. <ins>If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.</ins>
+                1. <ins>Set _done_ to *false*.</ins>
+                1. Repeat, while _done_ is *false*,
+                  1. Let _requiredModule_ be the last element in _stack_.
+                  1. Remove the last element of _stack_.
+                  1. Set _requiredModule_.[[Status]] to `"evaluated"`.
+                  1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
+              1. Return _index_.
+            </emu-alg>
+          </emu-clause>
+        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-dynamic-module-records">


### PR DESCRIPTION
I've included a sample spec diff here to alter execution order of Source Text Module Records to ensure an invariant for Abstract Module Records in a circular reference scenario.

#### What is Specified

In the following case:

a.mjs
```js
import './b.mjs';
export * from './x.mjs';
console.log('a exec');
```

b.mjs
```js
import * as a from './a.mjs';
console.log('b exec');
console.log(a);
```

x.mjs
```js
export var p = 5;
console.log('x exec');
```

If you run this today executing `a.mjs` you get the output:

```
b exec
[Module] { p: undefined }
x exec
a exec
```

The proposal here is to change the above execution order in the spec to rather look like:

```
x exec
b exec
[Module] { p: 5 }
a exec
```

**That is, when there is a circular reference, to execute modules that are not part of the cycle first, before executing the cycle module.**

The specification diff provided here achieves that.

_In the process, it does seem like it would make circular execution more useful in that non-circular dependencies are defined._

#### Why is this necessary

If you imagine that `x.mjs` is a dynamic module record, then we have inspected its export list (the module log above), before the module x has finished executing. This is a problem for dynamic modules as we change their export list after execution, so that a partial namespace must not be observable.

#### Why can't a partial namespace be observable?

It could certainly be an alternative to just accept that you could observe as a user partially-defined dynamic module exports, as this is quite an extreme edge case, but in the name of a spec actually being well defined it seems better to fix the problem.

#### How does the fix work?

We already track cycles uniquely in the spec using the `DFSAncestorIndex`. A unique `DFSAncestorIndex` corresponds to a unique sub-cycle of the graph. A graph without any cycles will have a single `DFSAncestorIndex` always matching the `DFSIndex`.

The `DFSAncestorIndex` is there to track that marking module records as "evaluated" is done on the correct execution subgraphs. This marking exactly happens in the right order we need, so moving execution to happen just like this same marking algorithm on the subset of the execution stack provides the fix.

//cc @bmeck @caridy